### PR TITLE
Fixed proxy_url in backend

### DIFF
--- a/src/jupyter_spark/__init__.py
+++ b/src/jupyter_spark/__init__.py
@@ -29,6 +29,6 @@ def load_jupyter_server_extension(nbapp):  # pragma: no cover
 
     nbapp.web_app.add_handlers(
         r'.*',  # match any host
-        [(spark.proxy_root + '.*', SparkHandler, {'spark': spark})]
+        [(spark.proxy_url + '.*', SparkHandler, {'spark': spark})]
     )
     nbapp.log.info("Jupyter-Spark enabled!")


### PR DESCRIPTION
`base_url` was ignored in handler. 
This uses the joined root and base url for the web handler.

Can you please add a test for this ;)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/jupyter-spark/23)

<!-- Reviewable:end -->
