### PR TITLE
Fix #29: Include base URL in the handler path

### DIFF
--- a/src/jupyter_spark/__init__.py
+++ b/src/jupyter_spark/__init__.py
@@ -29,6 +29,6 @@ def load_jupyter_server_extension(nbapp):  # pragma: no cover
 
     nbapp.web_app.add_handlers(
         r'.*',  # match any host
-        [(spark.proxy_root + '.*', SparkHandler, {'spark': spark})]
+        [(spark.proxy_url + '.*', SparkHandler, {'spark': spark})]
     )
     nbapp.log.info("Jupyter-Spark enabled!")


### PR DESCRIPTION
The handler isn't set up to be at the full path, which should include `base_url`, if set (which it isn't by default).  See #29.