### PR TITLE
Handle multiple Spark Sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,18 @@ install:
 	jupyter serverextension enable --py jupyter_spark
 	jupyter nbextension install --py jupyter_spark
 	jupyter nbextension enable --py jupyter_spark
+	@echo ""
+	@echo "NOTE: Copy ./src/magic/spark_progress.py into the startup folder, e.g. ~/.ipython/profile_default/startup/"
+	@echo ""
 
 uninstall:
 	jupyter serverextension disable --py jupyter_spark
 	jupyter nbextension disable --py jupyter_spark
 	jupyter nbextension uninstall --py jupyter_spark
 	pip uninstall -y jupyter-spark
+	@echo ""
+	@echo "NOTE: Remove spark_progress.py from startup folder, e.g. ~/.ipython/profile_default/startup/"
+	@echo ""
 
 clean: uninstall
 	rm -rf dist/

--- a/README.md
+++ b/README.md
@@ -77,12 +77,31 @@ pip uninstall jupyter-spark
 
 ## Configuration
 
-To change the URL of the Spark API that the job metadata is fetched from
-override the `Spark.url` config value, e.g. on the command line:
+The Spark API that the job metadata is fetched from can be different for each SparkContext. As default, for the first Spark context uses port 4040, for the second 4041 and so on. If however `spark.ui.port` is set to 0 in SparkConf, Spark will choose a random ephemeral port for the API. In order to support this behaviour (and allow more than one tab in Jupyter with a SparkContext), copy the Jupyter notebook magic `spark_progress.py` from the `src/magic` into your ipython profile's startup folder, e.g. for the default profile this is `~/.ipython/profile_default/startup/`.
 
+Then in your Spark notebook you can turn on Spark progress monitoring py providing the Spark API URL (e.g. `http://localhost:4040`)
+
+```python
+%spark_progress http://<spark-api-server>:<port>
 ```
-jupyter notebook --Spark.url="http://localhost:4040"
+
+or, if you use Spark 2.0 or newer, just provide the variable name that holds the SparkContext (`sc`) or SparkSession (`spark`):
+
+```python
+%spark_progress sc
 ```
+
+```python
+%spark_progress spark
+```
+
+To turn it off again use
+
+```python
+%spark_progress None
+```
+
+Note, these commands are line magics and need to have their own cell.
 
 ## Example
 

--- a/examples/Jupyter Spark example.ipynb
+++ b/examples/Jupyter Spark example.ipynb
@@ -44,7 +44,26 @@
     "spark = SparkSession \\\n",
     "            .builder \\\n",
     "            .appName(\"PythonPi\") \\\n",
+    "            .master(\"yarn\") \\\n",
+    "            .config(\"deploy-mode\", \"client\") \\\n",
     "            .getOrCreate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spark progress monitoring turned on\n"
+     ]
+    }
+   ],
+   "source": [
+    "%spark_progress spark"
    ]
   },
   {
@@ -56,11 +75,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "partitions = 2"
+    "partitions = 5"
    ]
   },
   {
@@ -72,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,14 +138,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pi is roughly 3.141880\n"
+      "Pi is roughly 3.141783\n"
      ]
     }
    ],
@@ -143,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/jupyter_spark/handlers.py
+++ b/src/jupyter_spark/handlers.py
@@ -18,9 +18,16 @@ class SparkHandler(IPythonHandler):
         the verbatim response.
         """
         http = httpclient.AsyncHTTPClient()
-        url = self.spark.backend_url(self.request)
-        self.spark.log.debug('Fetching from Spark %s', url)
-        http.fetch(url, self.handle_response)
+        spark_url = self.get_argument("spark_url", None)
+        if spark_url is not None:
+            url = self.spark.backend_url(spark_url, self.request.path)
+            http.fetch(url, self.handle_response)
+        else:
+            content_type = 'application/json'
+            content = json.dumps({'error': 'SPARK_URL_MISSING'})
+            self.set_header('Content-Type', content_type)
+            self.write(content)
+            self.finish()
 
     def handle_response(self, response):
         if response.error:

--- a/src/jupyter_spark/spark.py
+++ b/src/jupyter_spark/spark.py
@@ -28,11 +28,6 @@ class Spark(LoggingConfigurable):
     A config object that is able to replace URLs of the Spark frontend
     on the fly.
     """
-    url = Unicode(
-        'http://localhost:4040',
-        help='The URL of Spark API',
-    ).tag(config=True)
-
     proxy_root = Unicode(
         '/spark',
         help='The URL path under which the Spark API will be proxied',
@@ -43,9 +38,9 @@ class Spark(LoggingConfigurable):
         super(Spark, self).__init__(*args, **kwargs)
         self.proxy_url = url_path_join(self.base_url, self.proxy_root)
 
-    def backend_url(self, request):
-        request_path = request.uri[len(self.proxy_url):]
-        return url_path_join(self.url, request_path)
+    def backend_url(self, url, path):
+        request_path = path[len(self.proxy_root):]
+        return url_path_join(url, request_path)
 
     def replace(self, content):
         """

--- a/src/magic/spark_progress.py
+++ b/src/magic/spark_progress.py
@@ -1,0 +1,38 @@
+from __future__ import print_function
+
+from ipykernel.comm import Comm
+from IPython import get_ipython
+from IPython.core.magic import Magics, line_magic, magics_class
+
+
+@magics_class
+class SparkProgress(Magics):
+
+    @line_magic
+    def spark_progress(self, line):
+        """Toggle Spark progress being shown under cells"""
+
+        comm = Comm(target_name='spark_comm')
+        if line.startswith("http"):
+            url = line
+        else:
+            param = globals().get(line, None)
+            if type(param).__name__ == "SparkContext":
+                url = param.uiWebUrl
+            elif type(param).__name__ == "SparkSession":
+                url = param.sparkContext.uiWebUrl
+            else:
+                url = None
+
+        comm.send({'uiWebUrl': url})
+
+        if url is None:
+            print("No Spark Context given as parameter, turning Spark progress monitoring off")
+        else:
+            print("Spark progress monitoring turned on")
+
+        comm.close()
+
+
+ip = get_ipython()
+ip.register_magics(SparkProgress)


### PR DESCRIPTION
Proposal for [Issue 22](https://github.com/mozilla/jupyter-spark/issues/22):

In the Jupyter notebook a Jupyter Comm target gets opened to listen for messages from a python kernel. A new Jupyter Magic uses this comm target to forward the Spark API URL to the notebook: 

`%spark_progress spark`

where `spark` is the variable holding the Spark Session, so the magic can use `globals()["spark"].sparkContext.uiWebUrl` to get the actual Spark API Url.

Each call from the javascript notebook then forwards the Spark API Url as a query parameter `spark_url` to the backend handler which uses it to create the backend_url.

This allows for multiple SparkContexts in different tabs and even for `spark.ui.port=0` setting.